### PR TITLE
Don't set depth for tags filter anynore

### DIFF
--- a/resources/lib/navigation/tag_item.py
+++ b/resources/lib/navigation/tag_item.py
@@ -15,7 +15,7 @@ class TagItem(NavigationItem):
         (count, tags) = self._client.find_tags(has_type='scenes' if self._type == 'scene_tags' else self._browse_for)
         items = []
         for tag in tags:
-            criterion = {self._filter_name: {'modifier': 'INCLUDES_ALL', 'value': [tag['id']], 'depth': 0}}
+            criterion = {self._filter_name: {'modifier': 'INCLUDES_ALL', 'value': [tag['id']]}}
             item = self._create_item(tag['name'], image_path=tag['image_path'])
             url = self._create_url(tag['name'], criterion)
             items.append((item, url))


### PR DESCRIPTION
Fix compatibility issue with Stash 0.9.0 where depth can't be set for the tags filter as it will become available in Stash 0.10.0. Skipping the depth option is now also possible, since stashapp/stash#1733 makes it optional.

Fixes #2