### PR TITLE
Bugfix for listing filters with stash v0.23.1

### DIFF
--- a/resources/lib/criterion_parser.py
+++ b/resources/lib/criterion_parser.py
@@ -20,10 +20,12 @@ def parse_criterion(criterion):
 
     value = criterion.get('value', '')
     if isinstance(value, dict) and 'depth' in value:
-        if(value['items'] is None):
-            filter['value'] = list(map(lambda v: v['id'], value['excluded']))
-        else:
+        if 'items' in value:
             filter['value'] = list(map(lambda v: v['id'], value['items']))
+
+        if 'excluded' in value:
+            filter['excludes'] = list(map(lambda v: v['id'], value['excluded']))
+
         filter['depth'] = value['depth']
     elif isinstance(value, dict) and not value.keys() - ['value', 'value2']:
         filter.update(value)

--- a/resources/lib/criterion_parser.py
+++ b/resources/lib/criterion_parser.py
@@ -4,14 +4,11 @@ import json
 def parse(criterions):
     filter = {}
 
-    for json_criterion in criterions:
-        criterion = json.loads(json_criterion)
-
-        type = criterion['type']
-        if type in ('sceneIsMissing', 'imageIsMissing', 'performerIsMissing', 'galleryIsMissing', 'tagIsMissing', 'studioIsMissing', 'studioIsMissing'):
+    for criterion in criterions:
+        if criterion in ('sceneIsMissing', 'imageIsMissing', 'performerIsMissing', 'galleryIsMissing', 'tagIsMissing', 'studioIsMissing', 'studioIsMissing'):
             filter['is_missing'] = criterion['value']
         else:
-            filter[type] = parse_criterion(criterion)
+            filter[criterion] = parse_criterion(criterions[criterion])
 
     return filter
 
@@ -23,7 +20,10 @@ def parse_criterion(criterion):
 
     value = criterion.get('value', '')
     if isinstance(value, dict) and 'depth' in value:
-        filter['value'] = list(map(lambda v: v['id'], value['items']))
+        if(value['items'] is None):
+            filter['value'] = list(map(lambda v: v['id'], value['excluded']))
+        else:
+            filter['value'] = list(map(lambda v: v['id'], value['items']))
         filter['depth'] = value['depth']
     elif isinstance(value, dict) and not value.keys() - ['value', 'value2']:
         filter.update(value)

--- a/resources/lib/listing/listing.py
+++ b/resources/lib/listing/listing.py
@@ -116,13 +116,14 @@ class Listing(ABC):
     def _create_item_from_filter(self, filter: dict, override_title=None) -> [(xbmcgui.ListItem, str)]:
         title = override_title if override_title is not None else filter['name']
         item = xbmcgui.ListItem(label=title)
-        filter_data = json.loads(filter['filter'])
-        criterion_json = json.dumps(criterion_parser.parse(filter_data['c']))
+        find_filter = filter['find_filter']
+        object_filter = filter['object_filter']
+        criterion_json = json.dumps(criterion_parser.parse(object_filter))
 
         url = utils.get_url(list=self._type,
                             title=title,
                             criterion=criterion_json,
-                            sort_field=filter_data.get('sortby'),
-                            sort_dir=filter_data.get('sortdir')
+                            sort_field=find_filter.get('sort'),
+                            sort_dir=find_filter.get('direction')
                             )
         return item, url

--- a/resources/lib/stash_interface.py
+++ b/resources/lib/stash_interface.py
@@ -336,8 +336,15 @@ query findSceneMarkers($markers_filter: SceneMarkerFilterType, $filter: FindFilt
         query = """
 query findSavedFilters($mode: FilterMode!) {
     findSavedFilters(mode: $mode) {
-        name
-        filter
+        name,
+        object_filter,
+        find_filter {
+          q
+          page
+          per_page
+          sort
+          direction
+      }
     }
 }
 """
@@ -352,8 +359,15 @@ query findSavedFilters($mode: FilterMode!) {
         query = """
 query findDefaultFilter($mode: FilterMode!) {
     findDefaultFilter(mode: $mode) {
-        name
-        filter
+        name,
+        object_filter,
+        find_filter {
+          q
+          page
+          per_page
+          sort
+          direction
+      }
     }
 }
 """


### PR DESCRIPTION
This might not be a full fix for all changes and errors, its just what made it work for me and my filters. The filter property in the response is deprecated and split in two so there might be other issues in other parts of the plugin.