### PR TITLE
Bugfix for filter listing when items is null

### DIFF
--- a/resources/lib/criterion_parser.py
+++ b/resources/lib/criterion_parser.py
@@ -20,7 +20,7 @@ def parse_criterion(criterion):
 
     value = criterion.get('value', '')
     if isinstance(value, dict) and 'depth' in value:
-        if 'items' in value:
+        if 'items' in value and value['items'] is not None:
             filter['value'] = list(map(lambda v: v['id'], value['items']))
 
         if 'excluded' in value:
@@ -31,7 +31,7 @@ def parse_criterion(criterion):
         filter.update(value)
     elif isinstance(value, list):
         filter['value'] = list(map(lambda v: v['id'], value))
-    else:
+    elif value is not '':
         filter['value'] = value
 
     return filter

--- a/resources/lib/criterion_parser.py
+++ b/resources/lib/criterion_parser.py
@@ -20,10 +20,10 @@ def parse_criterion(criterion):
 
     value = criterion.get('value', '')
     if isinstance(value, dict) and 'depth' in value:
-        if 'items' in value and value['items'] is not None:
+        if value.get('items') is not None:
             filter['value'] = list(map(lambda v: v['id'], value['items']))
 
-        if 'excluded' in value:
+        if value.get('excluded') is not None:
             filter['excludes'] = list(map(lambda v: v['id'], value['excluded']))
 
         filter['depth'] = value['depth']
@@ -31,7 +31,7 @@ def parse_criterion(criterion):
         filter.update(value)
     elif isinstance(value, list):
         filter['value'] = list(map(lambda v: v['id'], value))
-    elif value is not '':
+    elif 'value' in criterion:
         filter['value'] = value
 
     return filter


### PR DESCRIPTION
Fix for listing of filter with items None
```
{'modifier': 'INCLUDES', 'value': {'depth': 0, 'excluded': [{'id': 813, 'label': 'Animated'}, {'id': 1315, 'label': 'Cock Hero'}, {'id': 496, 'label': 'Movies'}, {'id': 1034, 'label': 'PMV'}, {'id': 1316, 'label': 'Stim'}, {'id': 497, 'label': 'Compilation'}], 'items': None}}
```

Fix for opening of filters that have no value
```
      {
        "name": "Stashid missing",
        "object_filter": {
          "stash_id_endpoint": {
            "modifier": "IS_NULL"
          }
        },
        "find_filter": {
          "q": "",
          "page": 1,
          "per_page": 40,
          "sort": "date",
          "direction": "ASC"
        }
      },
```