### PR TITLE
Set scene title to filename as fallback if title is empty

### DIFF
--- a/resources/lib/listing/listing.py
+++ b/resources/lib/listing/listing.py
@@ -1,4 +1,5 @@
 import json
+import os.path
 from abc import ABC, abstractmethod
 from typing import Optional
 import xbmcgui
@@ -74,7 +75,8 @@ class Listing(ABC):
         pass
 
     def _create_item(self, scene: dict, **kwargs):
-        title = kwargs['title'] if 'title' in kwargs else scene['title']
+        title = kwargs['title'] if 'title' in kwargs else scene['title'] \
+            if not scene['title'] == '' else os.path.split(scene['files'][0]['path'])[1]
         screenshot = kwargs['screenshot'] if 'screenshot' in kwargs else scene['paths']['screenshot']
         file = scene['files'][0]
         # / 10 because rating is 1 to 100 and Kodi uses 1 to 10

--- a/resources/lib/stash_interface.py
+++ b/resources/lib/stash_interface.py
@@ -66,6 +66,7 @@ query findScenes($scene_filter: SceneFilterType, $filter: FindFilterType!) {
         audio_codec
         width
         height
+        path
       }
       studio {
         name
@@ -124,6 +125,7 @@ query findScene($id: ID) {
       audio_codec
       width
       height
+      path
     }
     studio {
       name
@@ -155,6 +157,7 @@ query findScene($id: ID) {
           audio_codec
           width
           height
+          path
         }
         studio {
           name
@@ -305,6 +308,7 @@ query findSceneMarkers($markers_filter: SceneMarkerFilterType, $filter: FindFilt
           audio_codec
           width
           height
+          path
         }
         studio {
           name


### PR DESCRIPTION
This PR uses the filename as fallback title for all scenes with an empty title attribute, for example because they haven't been scraped yet